### PR TITLE
Fixed problem of cloning site with site subdir

### DIFF
--- a/function/global.sh
+++ b/function/global.sh
@@ -134,7 +134,7 @@ demyx_permission() {
     chown -R demyx:demyx "$DEMYX"
 }
 demyx_app_config() {
-    DEMYX_GET_APP="$(find "$DEMYX_APP" -name "$DEMYX_TARGET")"
+    DEMYX_GET_APP="$(find "$DEMYX_APP" -name "$DEMYX_TARGET" | head -1)"
     [[ -f "$DEMYX_GET_APP"/.env ]] && source "$DEMYX_GET_APP"/.env
 }
 demyx_app_is_up() {


### PR DESCRIPTION
I encourntered problems while cloning a site with a cache plugin that uses the site-name as cache-directory. In this situation the `find "$DEMYX_APP" -name "$DEMYX_TARGET` gets two results and wont work as expected. It cannot determine the correct site name and the process stops in waiting for the database that wont get up.